### PR TITLE
Add principal component export for bg and sample in ancestry-predict.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,14 @@ You can use a background set of extracted `*.somalier` files, for example from t
 those samples to predict ancestry for a given set (or single sample). This would look like:
 
 ```
-python scripts/ancestry-predict.py --labels scripts/ancestry-labels-1kg.tsv --samples $MY_SAMPLES/*.somalier --backgrounds 1kg-somalier/*.somalier --plot plot.pdf --prefix my_sample
+python scripts/ancestry-predict.py --labels scripts/ancestry-labels-1kg.tsv --samples $MY_SAMPLES/*.somalier --backgrounds 1kg-somalier/*.somalier --plot my_folder/my_sample.pdf
 ```
 
-And output: `my_sample.background_pca.csv`, `my_sample.plot.pdf`, `my_sample.sample_prediction_pca.csv` and `my_sample.thousandG.npy`
+And output: 
+* `my_folder/my_sample.pcs.csv`
+* `my_folder/my_sample.pdf`
+* `my_folder/my_sample.ancestry_prediction.csv`
+* `my_folder/my_sample.thousandG.npy`
 
 The ancestry-predict.py and the `scripts/ancestry-labels-1kg.tsv` are in the somalier repository.
 The somalier files for thousand genomes can be downloaded from [here](https://zenodo.org/record/3479773/files/1kg.somalier.tar.gz?download=1)

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ You can use a background set of extracted `*.somalier` files, for example from t
 those samples to predict ancestry for a given set (or single sample). This would look like:
 
 ```
-python scripts/ancestry-predict.py --labels scripts/ancestry-labels-1kg.tsv --samples $MY_SAMPLES/*.somalier --backgrounds 1kg-somalier/*.somalier > sample-ancestries.txt
+python scripts/ancestry-predict.py --labels scripts/ancestry-labels-1kg.tsv --samples $MY_SAMPLES/*.somalier --backgrounds 1kg-somalier/*.somalier --plot plot.pdf --prefix my_sample
 ```
+
+And output: `my_sample.background_pca.csv`, `my_sample.plot.pdf`, `my_sample.sample_prediction_pca.csv` and `my_sample.thousandG.npy`
 
 The ancestry-predict.py and the `scripts/ancestry-labels-1kg.tsv` are in the somalier repository.
 The somalier files for thousand genomes can be downloaded from [here](https://zenodo.org/record/3479773/files/1kg.somalier.tar.gz?download=1)

--- a/scripts/ancestry-predict.py
+++ b/scripts/ancestry-predict.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
                 other=(pd.DataFrame(test_reduced, test_samples, labels_pc)))
         
         df_pca.index.name = "ancestry"
-        fp_pca = path.joinpath("{}.pcs.csv".format(prefix))
+        fp_pca = path.joinpath("{}.ancestry_pcs.csv".format(prefix))
         df_pca.to_csv(path_or_buf=fp_pca)
 
         # export predictions as csv

--- a/scripts/ancestry-predict.py
+++ b/scripts/ancestry-predict.py
@@ -128,10 +128,6 @@ if __name__ == "__main__":
     bg_reduced_df = pd.DataFrame(data=bg_reduced, index=bg_sample_df[label].values, columns=labels_pc)
     bg_reduced_df.index.name = "ancestry"
     bg_reduced_df.to_csv(path_or_buf="somalier.background_pca.csv")
-    
-    # export json
-    bg_reduced_df.reset_index(level=0, inplace=True)
-    bg_reduced_df.to_json(path_or_buf="somalier.background_pca.json",)
 
     if len(test_ABs) > 0:
         test_reduced = clf.named_steps["pca"].transform(test_ABs)

--- a/scripts/ancestry-predict.py
+++ b/scripts/ancestry-predict.py
@@ -125,7 +125,9 @@ if __name__ == "__main__":
     labels_pc = [("PC%d" % i) for i in range(1,(n_components+1))]
 
     # export csv
-    bg_reduced_df = pd.DataFrame(data=bg_reduced, index=bg_sample_df[label].values, columns=labels_pc)
+    bg_reduced_df = pd.DataFrame(
+        data=bg_reduced, 
+        index=bg_sample_df[label].values, columns=labels_pc)
     bg_reduced_df.index.name = "ancestry"
     bg_reduced_df.to_csv(path_or_buf="somalier.background_pca.csv")
 
@@ -135,7 +137,9 @@ if __name__ == "__main__":
         test_prob = clf.predict_proba(test_ABs)
 
         # export prediction and PC's as csv
-        sample_df = pd.DataFrame(data=np.hstack((test_prob.round(2), test_reduced)), index=test_samples, columns=[*targetL, *labels_pc])
+        sample_df = pd.DataFrame(
+            data=np.hstack((test_prob.round(2), test_reduced)), 
+            index=test_samples, columns=[*targetL, *labels_pc])
         sample_df.index.name = "#sample"
         sample_df.to_csv(path_or_buf="somalier.sample_prediction_pca.csv")
 


### PR DESCRIPTION
To enable creation of PCA plots in MultiQC, I have modified the script to export csv files containing the predictions and PC's.

These changes affect the way ancestry-predict is called:
### ORIGINAL
`python scripts/ancestry-predict.py --labels scripts/ancestry-labels-1kg.tsv --samples $MY_SAMPLES/*.somalier --backgrounds 1kg-somalier/*.somalier > sample-ancestries.txt`

Outputs:
- `sample-ancestries.txt`
- `thousandG.npy`

### NEW
`python somalier/scripts/ancestry-predict.py --labels somalier/scripts/ancestry-labels-1kg.tsv --samples $MY_SAMPLES/*.somalier --backgrounds 1kg-somalier/*.somalier`

Shows the plot

`python3 somalier/scripts/ancestry-predict.py --labels somalier/scripts/ancestry-labels-1kg.tsv --samples data/*.somalier --backgrounds 1kg-somalier/*.somalier --plot mydir/mysample.pdf`

Outputs in dir: "mydir":
- `mysample.ancestry_pcs.csv`
- `mysample.ancestry_prediction.csv`
- `mysample.pdf`
- `mysample.thousandG.npy`


### Considerations
- The script has two modes: show the plot or generate+save files. This depends on specifying a save-location for the plot.
- I chose .csv as output format since this reflects the MultiQC/Somalier pull-request.
- If the user wants to use their own ancestry-labels, one could modify the "thousandG.npy"-filename to reflect this.