### PR TITLE
Added option to prefix sample names in the digests

### DIFF
--- a/somalier.nimble
+++ b/somalier.nimble
@@ -17,12 +17,12 @@ license       = "academic only"
 
 # Dependencies
 
-requires "nim >= 0.19.0", "hts >= 0.3.0", "https://github.com/brentp/slivar#head", "https://github.com/brentp/hileup", "argparse", "lapper", "arraymancer#head"
+requires "nim >= 0.19.0", "hts >= 0.3.0", "https://github.com/brentp/slivar", "https://github.com/brentp/hileup", "argparse", "lapper", "arraymancer#head"
 srcDir = "src"
 
-#bin = @["./somalier.nim"]
+bin = @["./somalier.bin"]
+#bin = "src/somalier"
 
 task test, "run the tests":
   exec "nim c  -d:useSysAssert -d:useGcAssert --lineDir:on --debuginfo -r tests/test_groups"
   exec "bash tests/functional-tests.sh"
-

--- a/src/somalier.nim
+++ b/src/somalier.nim
@@ -171,7 +171,7 @@ proc extract_main() =
     option("-s", "--sites", help="sites vcf file of variants to extract")
     option("-f", "--fasta", help="path to reference fasta file")
     option("-d", "--out-dir", help="path to output directory", default=".")
-    option("-p", "--prefix", help="prefix for the sample name stored inside the digest", default="")
+    option("--sample-prefix", help="prefix for the sample name stored inside the digest", default="")
     arg("sample_file", help="single-sample CRAM/BAM/GVCF file or multi/single-sample VCF from which to extract")
 
   let opts = p.parse(argv)
@@ -208,7 +208,7 @@ proc extract_main() =
     sample_counts = @[cnts]
 
   for cnts in sample_counts:
-    var stored_sample_name : string = opts.prefix & cnts.sample_name
+    var stored_sample_name : string = opts.sample_prefix & cnts.sample_name
 
     var s = newFileStream(opts.outdir & "/" & cnts.sample_name & ".somalier", fmWrite)
     s.write(formatVersion.uint8)

--- a/src/somalier.nim
+++ b/src/somalier.nim
@@ -171,6 +171,7 @@ proc extract_main() =
     option("-s", "--sites", help="sites vcf file of variants to extract")
     option("-f", "--fasta", help="path to reference fasta file")
     option("-d", "--out-dir", help="path to output directory", default=".")
+    option("-p", "--prefix", help="prefix for the sample name stored inside the digest", default="")
     arg("sample_file", help="single-sample CRAM/BAM/GVCF file or multi/single-sample VCF from which to extract")
 
   let opts = p.parse(argv)
@@ -207,10 +208,12 @@ proc extract_main() =
     sample_counts = @[cnts]
 
   for cnts in sample_counts:
+    var stored_sample_name : string = opts.prefix & cnts.sample_name
+
     var s = newFileStream(opts.outdir & "/" & cnts.sample_name & ".somalier", fmWrite)
     s.write(formatVersion.uint8)
-    s.write(cnts.sample_name.len.uint8)
-    s.write(cnts.sample_name)
+    s.write(stored_sample_name.len.uint8)
+    s.write(stored_sample_name)
     s.write(cnts.sites.len.uint16)
     s.write(cnts.x_sites.len.uint16)
     s.write(cnts.y_sites.len.uint16)


### PR DESCRIPTION
I have thousands of samples from SNP chips, Illumina wgs, Nanopore and what not and sometimes the sample names from different platforms are identical, or the source platform is difficult to identify. This lets user to add e.g. the source platform or source bam/vcf file to the sample name which is stored inside the digest.  

(nimble mods for getting somalier compile on my platform)