### PR TITLE
Allows for mix of AD and MIN_DP in combined GVCF files, prioritizes exact matches of alleles when selecting sites

### DIFF
--- a/src/somalier.nim
+++ b/src/somalier.nim
@@ -35,20 +35,17 @@ proc looks_like_gvcf_variant(v:Variant): bool {.inline.} =
       return true
 
 proc get_variant(ivcf:VCF, site:Site): Variant =
-  var matches: seq[Variant]
   var gvcfs: seq[Variant]
   for v in ivcf.query(&"{site.chrom}:{site.position+1}-{site.position+2}"):
     if v.start == site.position and (
       (v.REF == site.A_allele and v.ALT[0] == site.B_allele) or
       (v.REF == site.B_allele and v.ALT[0] == site.A_allele)):
-      matches.add(v.copy())
+      return(v.copy())
 
     if v.looks_like_gvcf_variant:
       gvcfs.add(v.copy())
 
-  if matches.len > 0:
-    return matches[0]
-  elif gvcfs.len > 0:
+  if gvcfs.len > 0:
     return gvcfs[0]
 
 var allowed_filters = @["PASS", "", ".", "RefCall"]


### PR DESCRIPTION
1. Somalier was assuming that all samples for a given variant would use either AD or MIN_DP. That's incorrect when working with a combined GVCF, because the samples with reference genotypes were using MIN_DP and those with any non-reference reads were using ALT. Iterating over the AD array and using MIN_DP where nref hadn't been set fixed this.

2. GVCFs allow for overlapping entries, generally of an indel + a SNP. When somalier was selecting variant sites that intersected with the coordinates for a site from the site VCF, it was capturing both the indel and the SNP for these cases, and if the indel preceded the SNP in the GVCF, it was returning that. This meant that the read count information was being taken from the wrong site. This scenario is much more common when you have multiple samples in a GVCF, which is why I noticed it. Iterating over all returned sites and preferentially returning sites that matched position and alleles solved most of the rest of the mismatched sites.

A multi sample GVCF with scrambled genotypes that covers the above two scenarios is attached (with txt extension).

[test.g.vcf.txt](https://github.com/brentp/somalier/files/4280439/test.g.vcf.txt)

