### PR TITLE
recognize refseq accessions for chromosomes X and Y

### DIFF
--- a/src/somalier.nim
+++ b/src/somalier.nim
@@ -110,7 +110,7 @@ proc get_ref_alt_counts(ivcf:VCF, sites:seq[Site], fai:Fai=nil): seq[counts] =
     zeroMem(AD[0].addr, AD.len * sizeof(AD[0]))
     var v = ivcf.get_variant(site)
     # NOTE that if Status is OK, then we just fill AD
-    if v == nil or ($v.CHROM notin ["chrX", "X", "chrY", "Y"] and v.FILTER notin allowed_filters) or v.format.get("AD", AD) != Status.OK:
+    if v == nil or ($v.CHROM notin ["chrX", "NC_000023.10", "NC_000023.11", "X", "chrY", "NC_000024.9", "NC_000024.10", "Y"] and v.FILTER notin allowed_filters) or v.format.get("AD", AD) != Status.OK:
       AD.setLen(vcf_samples.len * 2)
       if v.ok and not has_AD:
         if AD.fill(v.format.genotypes(x).alts):
@@ -149,9 +149,9 @@ proc get_ref_alt_counts(ivcf:VCF, sites:seq[Site], fai:Fai=nil): seq[counts] =
         swap(ac.nref, ac.nalt)
 
       case site.chrom:
-        of ["X", "chrX"]:
+        of ["X", "chrX", "NC_000023.10", "NC_000023.11"]:
           result[j].x_sites.add(ac)
-        of ["Y", "chrY"]:
+        of ["Y", "chrY", "NC_000024.9", "NC_000024.10"]:
           result[j].y_sites.add(ac)
         else:
           result[j].sites.add(ac)
@@ -181,9 +181,9 @@ proc get_ref_alt_counts(ibam:Bam, sites:seq[Site], fai:Fai): counts =
         ac.nother.inc
 
     case site.chrom:
-      of ["X", "chrX"]:
+      of ["X", "chrX", "NC_000023.10", "NC_000023.11"]:
         result.x_sites.add(ac)
-      of ["Y", "chrY"]:
+      of ["Y", "chrY", "NC_000024.9", "NC_000024.10"]:
         result.y_sites.add(ac)
       else:
         result.sites.add(ac)

--- a/src/somalierpkg/findsites.nim
+++ b/src/somalierpkg/findsites.nim
@@ -139,7 +139,7 @@ proc findsites_main*() =
 
   for v in vcf:
     if v.c == nil: break
-    if $v.CHROM notin ["chrY", "Y", "chrX", "X"] and v.REF == "C": continue
+    if $v.CHROM notin ["chrY", "NC_000024.9", "NC_000024.10", "Y", "chrX", "NC_000023.10", "NC_000023.11", "X"] and v.REF == "C": continue
     if v.ALT.len == 0: continue
     total_count += 1
     if v.CHROM != last_chrom:
@@ -158,7 +158,7 @@ proc findsites_main*() =
 
 
     # stuff outside of PAR on human only.
-    if $last_chrom in ["X", "chrX"] and (v.start < 2781479 or v.start > 154931044) : continue
+    if $last_chrom in ["X", "chrX", "NC_000023.10", "NC_000023.11"] and (v.start < 2781479 or v.start > 154931044) : continue
 
     if v.info.get(field_AF, afs) != Status.OK:
       if error_count < 10:
@@ -185,13 +185,13 @@ proc findsites_main*() =
       snps.mGetOrPut($v.CHROM, newSeq[region]()).add(r)
 
     # check exclude after putting into interval trees
-    if gno != nil and gno.contains(v) and $v.CHROM notin ["chrX", "X"]:
+    if gno != nil and gno.contains(v) and $v.CHROM notin ["chrX", "NC_000023.10", "NC_000023.11", "X"]:
       continue
 
     var info = v.info
-    if info.get(field_AN, ans) == Status.OK and (($v.CHROM notin ["chrX", "X", "chrY", "Y"]) and ans[0] < min_AN) :
+    if info.get(field_AN, ans) == Status.OK and (($v.CHROM notin ["chrX", "NC_000023.10", "NC_000023.11", "X", "chrY", "NC_000024.9", "NC_000024.10", "Y"]) and ans[0] < min_AN) :
       continue
-    if $v.CHROM in ["chrY", "Y", "chrX", "X"]:
+    if $v.CHROM in ["chrY", "NC_000024.9", "NC_000024.10", "Y", "chrX", "NC_000023.10", "NC_000023.11", "X"]:
       if afs[0] < 0.04 or afs[0] > 0.96: continue
     else:
       if afs[0] < min_AF or afs[0] > (1 - min_AF): continue
@@ -203,13 +203,13 @@ proc findsites_main*() =
     if info.get("OLD_VARIANT", oms) == Status.OK:
       continue
 
-    if $v.CHROM notin ["chrY", "Y"] and info.has_flag("segdup"):
+    if $v.CHROM notin ["chrY", "NC_000024.9", "NC_000024.10", "Y"] and info.has_flag("segdup"):
       continue
     if info.has_flag("lcr"):
       continue
 
     # BaseQRankSum=0.571;ClippingRankSum=0;MQRankSum=0.101;ReadPosRankSum
-    if $v.CHROM notin ["chrX", "X", "chrY", "Y"]:
+    if $v.CHROM notin ["chrX", "NC_000023.10", "NC_000023.11", "X", "chrY", "NC_000024.9", "NC_000024.10", "Y"]:
       var skip = false
       for rs in @["BaseQ", "MQ", "Clipping", "ReadPos"]:
         if info.get(rs & "RankSum", ranksum) == Status.OK and abs(ranksum[0]) > 2.4:
@@ -275,22 +275,22 @@ proc findsites_main*() =
 
     if len(vs) > 0:
       let d = v.v.closest_dist(vs)
-      if chrom in ["chrY", "Y"]:
+      if chrom in ["chrY", "NC_000024.9", "NC_000024.10", "Y"]:
         if d < 200:
           continue
-      elif chrom in ["chrX", "X"]:
+      elif chrom in ["chrX", "NC_000023.10", "NC_000023.11", "X"]:
         if d < 1000:
           continue
       elif d < snp_dist:
         continue
 
     #discard wtr.write_variant(v.v)
-    if chrom in ["chrX", "X", "Y", "chrY"]:
-      if chrom in ["chrX", "X"]:
+    if chrom in ["chrX", "NC_000023.10", "NC_000023.11", "X", "Y", "chrY", "NC_000024.9", "NC_000024.10"]:
+      if chrom in ["chrX", "NC_000023.10", "NC_000023.11", "X"]:
           if xcounts > 10000:
               continue
           xcounts += 1
-      if chrom in ["chrY", "Y"]:
+      if chrom in ["chrY", "NC_000024.9", "NC_000024.10", "Y"]:
           if ycounts > 5000:
               continue
           ycounts += 1


### PR DESCRIPTION
This commit makes it possible to extract data from corresponding bam/vcf files (with an appropriate sites file) where the chromosomes, instead of being named "ensembl-style" like "X" or "ucsc-style" like "chrX", have the actual refseq accession (like NC_000023.10). The corresponding names for GRCh37 and GRCh38 assemblies are included.