### PR TITLE
use docker multi-stage build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
-FROM brentp/musl-hts-nim:latest
+FROM brentp/musl-hts-nim:latest AS build
 
-# for nextflow
-RUN apk add bash procps
 
 RUN cd / &&    \
     git clone -b master --depth 5 https://github.com/brentp/somalier.git && \
@@ -10,10 +8,16 @@ RUN cd / &&    \
     /root/.nimble/bin/nimble install -d -y
 
 RUN cd /somalier &&  \
-    nim c -d:danger -d:nsb_static -d:release -d:openmp -d:blas=openblas -d:lapack=openblas -o:/usr/bin/somalier src/somalier && \
-    cp scripts/ancestry-labels-1kg.tsv / && \
-    rm -rf /somalier && somalier --help
+    nim c -d:danger -d:nsb_static -d:release -d:openmp -d:blas=openblas -d:lapack=openblas -o:/usr/bin/somalier src/somalier
 
-ENV somalier_ancestry_labels /ancestry_labels-1kg.tsv
+FROM alpine:3.21
+
+# for nextflow
+RUN apk add --no-cache bash procps
+
+COPY --from=build /usr/bin/somalier /usr/bin/somalier
+COPY --from=build /somalier/scripts/ancestry-labels-1kg.tsv /
+
+ENV somalier_ancestry_labels=/ancestry_labels-1kg.tsv
 
 


### PR DESCRIPTION
This reduces the docker image size from ~1.19GB to ~43MB, for approximately 96% savings!

Even better (from reproducibility standpoint) would be to build from something more formally-specified than brentp/musl-hts-nim:latest, and potentially more up-to-date, but with quick look some of the static libraries (e.g., for openmp/blas) wouldn't necessarily be available in a newer alpine version.